### PR TITLE
finished add tags, ticket #20

### DIFF
--- a/TabloidCLI/Repositories/TagRepository.cs
+++ b/TabloidCLI/Repositories/TagRepository.cs
@@ -46,7 +46,17 @@ namespace TabloidCLI
 
         public void Insert(Tag tag)
         {
-            throw new NotImplementedException();
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"INSERT INTO Tag (Name)
+                                                     VALUES (@name)";
+                    cmd.Parameters.AddWithValue("@name", tag.Name);
+                    cmd.ExecuteNonQuery();
+                }
+            }
         }
 
         public void Update(Tag tag)

--- a/TabloidCLI/UserInterfaceManagers/TagManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/TagManager.cs
@@ -1,14 +1,20 @@
 ﻿using System;
+using System.Threading.Channels;
+using TabloidCLI.Models;
 
 namespace TabloidCLI.UserInterfaceManagers
 {
     public class TagManager : IUserInterfaceManager
     {
         private readonly IUserInterfaceManager _parentUI;
-
+        private TagRepository _tagRepository;
+        private string _connectionString;
         public TagManager(IUserInterfaceManager parentUI, string connectionString)
         {
             _parentUI = parentUI;
+            _tagRepository = new TagRepository(connectionString);
+            _connectionString = connectionString;
+
         }
 
         public IUserInterfaceManager Execute()
@@ -51,7 +57,11 @@ namespace TabloidCLI.UserInterfaceManagers
 
         private void Add()
         {
-            throw new NotImplementedException();
+            Tag tag = new Tag();
+            Console.WriteLine("Enter tag: ");
+            tag.Name = Console.ReadLine();
+            _tagRepository.Insert(tag);
+            Console.WriteLine("Tag added.");
         }
 
         private void Edit()


### PR DESCRIPTION
As an application user I would like to be able to add a new keyword that I can use to tag a blog, author or post throughout the application so that I can have access to the keywords I think are appropriate.

Given the user is viewing the Tag Management menu
When they select the option to add a tag
Then they should be prompted to enter the new tag's name