### PR TITLE
finished list tags, ticket #21

### DIFF
--- a/TabloidCLI/UserInterfaceManagers/TagManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/TagManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Channels;
 using TabloidCLI.Models;
 
@@ -52,7 +53,11 @@ namespace TabloidCLI.UserInterfaceManagers
 
         private void List()
         {
-            throw new NotImplementedException();
+            List<Tag> tags = _tagRepository.GetAll();
+            foreach (Tag tag in tags)
+            {
+                Console.WriteLine(tag.Name);
+            }
         }
 
         private void Add()


### PR DESCRIPTION
As an application user I would like to be able to view a list of keywords that I might use to tag blogs, authors and posts so that I can determine if there are any missing or any that I no longer want.

Given the user is viewing the Tag Management menu
When they select the option to list tags
Then they should see each tag's name