### PR TITLE
Wh edit tags

### DIFF
--- a/TabloidCLI/Repositories/TagRepository.cs
+++ b/TabloidCLI/Repositories/TagRepository.cs
@@ -61,7 +61,20 @@ namespace TabloidCLI
 
         public void Update(Tag tag)
         {
-            throw new NotImplementedException();
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"UPDATE Tag 
+                                           SET Name = @name
+                                         WHERE id = @id";
+
+                    cmd.Parameters.AddWithValue("@name", tag.Name);
+                    cmd.Parameters.AddWithValue("@id", tag.Id);
+                    cmd.ExecuteNonQuery();
+                }
+            }
         }
 
         public void Delete(int id)

--- a/TabloidCLI/UserInterfaceManagers/TagManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/TagManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Channels;
 using TabloidCLI.Models;
 
@@ -52,7 +53,11 @@ namespace TabloidCLI.UserInterfaceManagers
 
         private void List()
         {
-            throw new NotImplementedException();
+            List<Tag> tags = _tagRepository.GetAll();
+            foreach (Tag tag in tags)
+            {
+                Console.WriteLine(tag.Name);
+            }
         }
 
         private void Add()

--- a/TabloidCLI/UserInterfaceManagers/TagManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/TagManager.cs
@@ -51,6 +51,7 @@ namespace TabloidCLI.UserInterfaceManagers
             }
         }
 
+
         private void List()
         {
             List<Tag> tags = _tagRepository.GetAll();
@@ -59,7 +60,36 @@ namespace TabloidCLI.UserInterfaceManagers
                 Console.WriteLine(tag.Name);
             }
         }
+        private Tag Choose(string prompt = null)
+        {
+            if (prompt == null)
+            {
+                prompt = "Please choose a tag:";
+            }
 
+            Console.WriteLine(prompt);
+
+            List<Tag> tags = _tagRepository.GetAll();
+
+            for (int i = 0; i < tags.Count; i++)
+            {
+                Tag tag = tags[i];
+                Console.WriteLine($" {i + 1}) {tag.Name}");
+            }
+            Console.Write("> ");
+
+            string input = Console.ReadLine();
+            try
+            {
+                int choice = int.Parse(input);
+                return tags[choice - 1];
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Invalid Selection");
+                return null;
+            }
+        }
         private void Add()
         {
             Tag tag = new Tag();
@@ -71,7 +101,15 @@ namespace TabloidCLI.UserInterfaceManagers
 
         private void Edit()
         {
-            throw new NotImplementedException();
+            Tag tagToEdit = Choose("Which tag would you like to edit? ");
+            Console.WriteLine();
+            Console.Write("New tag name (blank to leave unchanged): ");
+            string name = Console.ReadLine();
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                tagToEdit.Name = name;
+            }
+            _tagRepository.Update(tagToEdit);
         }
 
         private void Remove()


### PR DESCRIPTION
As a post connoisseur I would like to be able to edit tag so that I can use a more appropriate value.

Given the user is viewing the Tag Management menu
When they select the option to edit a tag
Then they should be presented with a list of tags to choose from

Given the user chooses a tag
When they enter the selection and hit enter
Then the user should be given the ability to enter new information for the tag's name

Given the user has been prompted to enter a new value for a property
When the user hits enter without typing anything
Or When the user only enters spaces
Then the property's value should NOT be changed