### PR TITLE
Wh blog details - ticket #25

### DIFF
--- a/TabloidCLI/Repositories/BlogRepository.cs
+++ b/TabloidCLI/Repositories/BlogRepository.cs
@@ -102,26 +102,21 @@ namespace TabloidCLI.Repositories
 
         public void Update(Blog blog)
         {
-            //using (SqlConnection conn = Connection)
-            //{
-            //    conn.Open();
-            //    using (SqlCommand cmd = conn.CreateCommand())
-            //    {
-            //        cmd.CommandText = @"UPDATE Author 
-            //                               SET FirstName = @firstName,
-            //                                   LastName = @lastName,
-            //                                   bio = @bio
-            //                             WHERE id = @id";
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"UPDATE Blog 
+                                           SET Title = @title, URL = @url
+                                         WHERE id = @id";
 
-            //        cmd.Parameters.AddWithValue("@firstName", author.FirstName);
-            //        cmd.Parameters.AddWithValue("@lastName", author.LastName);
-            //        cmd.Parameters.AddWithValue("@bio", author.Bio);
-            //        cmd.Parameters.AddWithValue("@id", author.Id);
-
-            //        cmd.ExecuteNonQuery();
-            //    }
-            //}
-            throw new NotImplementedException();
+                    cmd.Parameters.AddWithValue("@title", blog.Title);
+                    cmd.Parameters.AddWithValue("@url", blog.Url);
+                    cmd.Parameters.AddWithValue("@id", blog.Id);
+                    cmd.ExecuteNonQuery();
+                }
+            }
         }
 
         /* Delete a blog matching given id in the database */

--- a/TabloidCLI/UserInterfaceManagers/BlogDetailManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/BlogDetailManager.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using TabloidCLI.Models;
+using TabloidCLI.Repositories;
+
+namespace TabloidCLI.UserInterfaceManagers
+{
+    internal class BlogDetailManager : IUserInterfaceManager
+    {
+        private IUserInterfaceManager _parentUI;
+        private BlogRepository _blogRepository;
+        private PostRepository _postRepository;
+        private TagRepository _tagRepository;
+        private int _blogId;
+
+        public BlogDetailManager(IUserInterfaceManager parentUI, string connectionString, int blogId)
+        {
+            _parentUI = parentUI;
+            _blogRepository = new BlogRepository(connectionString);
+            _postRepository = new PostRepository(connectionString);
+            _tagRepository = new TagRepository(connectionString);
+            _blogId = blogId;
+        }
+
+        public IUserInterfaceManager Execute()
+        {
+            Blog blog = _blogRepository.Get(_blogId);
+            Console.WriteLine($"{blog.Title} Details");
+            Console.WriteLine(" 1) View");
+            Console.WriteLine(" 2) View Blog Posts");
+            Console.WriteLine(" 3) Add Tag");
+            Console.WriteLine(" 4) Remove Tag");
+            Console.WriteLine(" 0) Go Back");
+
+            Console.Write("> ");
+            string choice = Console.ReadLine();
+            switch (choice)
+            {
+                case "1":
+                    View();
+                    return this;
+                case "2":
+                    ViewBlogPosts();
+                    return this;
+                case "3":
+                    AddTag();
+                    return this;
+                case "4":
+                    RemoveTag();
+                    return this;
+                case "0":
+                    return _parentUI;
+                default:
+                    Console.WriteLine("Invalid Selection");
+                    return this;
+            }
+        }
+
+        private void View()
+        {
+            Blog blog = _blogRepository.Get(_blogId);
+            Console.WriteLine($"Name: {blog.Title}");
+            Console.WriteLine($"Bio: {blog.Url}");
+        }
+
+        private void ViewBlogPosts()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void AddTag()
+        {
+           throw new NotImplementedException();
+        }
+
+        private void RemoveTag()
+        {
+           throw new NotImplementedException();
+        }
+    }
+}

--- a/TabloidCLI/UserInterfaceManagers/BlogManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/BlogManager.cs
@@ -122,34 +122,28 @@ namespace TabloidCLI.UserInterfaceManagers
         }
         private void Edit()
         {
-            //Author authorToEdit = Choose("Which author would you like to edit?");
-            //if (authorToEdit == null)
-            //{
-            //    return;
-            //}
+            Blog blogToEdit = Choose("Which blog would you like to edit?");
+            if (blogToEdit == null)
+            {
+                return;
+            }
 
-            //Console.WriteLine();
-            //Console.Write("New first name (blank to leave unchanged: ");
-            //string firstName = Console.ReadLine();
-            //if (!string.IsNullOrWhiteSpace(firstName))
-            //{
-            //    authorToEdit.FirstName = firstName;
-            //}
-            //Console.Write("New last name (blank to leave unchanged: ");
-            //string lastName = Console.ReadLine();
-            //if (!string.IsNullOrWhiteSpace(lastName))
-            //{
-            //    authorToEdit.LastName = lastName;
-            //}
-            //Console.Write("New bio (blank to leave unchanged: ");
-            //string bio = Console.ReadLine();
-            //if (!string.IsNullOrWhiteSpace(bio))
-            //{
-            //    authorToEdit.Bio = bio;
-            //}
-
-            //_authorRepository.Update(authorToEdit);
-            throw new NotImplementedException();
+            Console.WriteLine();
+            Console.Write("New title (blank to leave unchanged): ");
+            string title = Console.ReadLine();
+            if (!string.IsNullOrWhiteSpace(title))
+            {
+                blogToEdit.Title = title;
+            }
+            Console.Write("New URL (blank to leave unchanged): ");
+            string url = Console.ReadLine();
+            if (!string.IsNullOrWhiteSpace(url))
+            {
+                blogToEdit.Url = url;
+            }
+            _blogRepository.Update(blogToEdit);
+            Console.WriteLine("Edited blog.");
+            Console.WriteLine("");
         }
 
         /* Remove a given blog in the database to the Console */

--- a/TabloidCLI/UserInterfaceManagers/BlogManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/BlogManager.cs
@@ -37,16 +37,15 @@ namespace TabloidCLI.UserInterfaceManagers
                     return this;
                 case "2":
                     Blog blog = Choose();
-                    /* Remove null when Details are fully implemented */
-                    return null;
-                    /*if (blog == null)
+                    
+                    if (blog == null)
                     {
                         return this;
                     }
                     else
                     {
                         return new BlogDetailManager(this, _connectionString, blog.Id);
-                    }*/
+                    }
                 case "3":
                     Add();
                     return this;


### PR DESCRIPTION
As a blog connoisseur I would like to view details of a blog so that I can focus on a particular blog and not the entire list of blogs.

Given the user is viewing the Blog Management menu
When they select the option to view blog details
Then they should be presented with a list of blogs to choose from

Given the user chooses an blog
When they enter the selection and hit enter
Then the Blog Details menu should be displayed

Given the user wishes to view the blog details
When they select "View"
Then the blog's title and url should be displayed

The Blog Detail menu should have the following options:

View
Add Tag
Remove Tag
View Posts
Return
NOTE: The other menu options will be outlined in future stories.